### PR TITLE
🐛 fix: 배포된 앱에서 트레이 아이콘 미표시 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
     "files": [
       "out/**/*"
     ],
+    "extraResources": [
+      {
+        "from": "build/tray-icon.png",
+        "to": "tray-icon.png"
+      }
+    ],
     "mac": {
       "target": "dmg",
       "category": "public.app-category.productivity",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,7 +95,9 @@ async function refreshTrayUsageTitle(): Promise<void> {
 }
 
 function createTray(): void {
-  const iconPath = join(__dirname, "../../build/tray-icon.png");
+  const iconPath = app.isPackaged
+    ? join(process.resourcesPath, "tray-icon.png")
+    : join(__dirname, "../../build/tray-icon.png");
   const icon = nativeImage.createFromPath(iconPath).resize({ width: 20, height: 20 });
   icon.setTemplateImage(false);
 


### PR DESCRIPTION
extraResources로 tray-icon.png를 앱 번들에 포함하고,
app.isPackaged 분기로 패키지/개발 환경에 맞는 경로를 사용하도록 수정

## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항
